### PR TITLE
add new methods (subscribe, gift, renew, raid)

### DIFF
--- a/Source/TwitchInteraction/Private/TwitchEventSub.cpp
+++ b/Source/TwitchInteraction/Private/TwitchEventSub.cpp
@@ -200,7 +200,7 @@ void UTwitchEventSub::RequestEventSubs() {
 
   FTwitchEventSubSubscriptionChannelFollowRequest followRequest;
   followRequest.type = "channel.follow";
-  followRequest.type = "2";
+  followRequest.version = "2";
   followRequest.condition.broadcaster_user_id = channelId;
   followRequest.condition.moderator_user_id = channelId;
   followRequest.transport.method = "websocket";
@@ -245,11 +245,11 @@ void UTwitchEventSub::RequestEventSubs() {
   subscriptions.Add(subscriptionRenewResult);
 
   FTwitchEventSubSubscriptionRaidRequest raidRequest;
-  subscriptionRenewRequest.type = "channel.raid";
-  subscriptionRenewRequest.version = "1";
-  subscriptionRenewRequest.condition.broadcaster_user_id = channelId;
-  subscriptionRenewRequest.transport.method = "websocket";
-  subscriptionRenewRequest.transport.session_id = sessionId;
+  raidRequest.type = "channel.raid";
+  raidRequest.version = "1";
+  raidRequest.condition.broadcaster_user_id = channelId;
+  raidRequest.transport.method = "websocket";
+  raidRequest.transport.session_id = sessionId;
   FString raidResult;
   FJsonObjectConverter::UStructToJsonObjectString(raidRequest, raidResult, 0, 0,
                                                   0, nullptr, false);

--- a/Source/TwitchInteraction/Private/TwitchEventSub.cpp
+++ b/Source/TwitchInteraction/Private/TwitchEventSub.cpp
@@ -127,6 +127,15 @@ void UTwitchEventSub::ProcessMessage(const FString _jsonStr) {
         return;
       }
       OnChannelSubscribed.Broadcast(redemptionMessage.payload.event);
+    } else if (targetMessage.metadata.subscription_type ==
+               "channel.subscription.gift") {
+      FTwitchEventSubSubscriptionGiftMessage redemptionMessage;
+      if (!FJsonObjectConverter::JsonObjectStringToUStruct(
+              _jsonStr, &redemptionMessage, 0, 0)) {
+        UE_LOG(LogTemp, Error, TEXT("Deserialize failed - %s"), *_jsonStr);
+        return;
+      }
+      OnChannelSubscriptionGifted.Broadcast(redemptionMessage.payload.event);
     }
   }
 };
@@ -195,7 +204,17 @@ void UTwitchEventSub::RequestEventSubs() {
       subscribeRequest, subscribeResult, 0, 0, 0, nullptr, false);
   subscriptions.Add(subscribeResult);
 
-  //  subscriptions.Add("channel.subscription.gift");
+  FTwitchEventSubSubscriptionSubscriptionGiftRequest subscriptionGiftRequest;
+  subscriptionGiftRequest.type = "channel.subscription.gift";
+  subscriptionGiftRequest.version = "1";
+  subscriptionGiftRequest.condition.broadcaster_user_id = channelId;
+  subscriptionGiftRequest.transport.method = "websocket";
+  subscriptionGiftRequest.transport.session_id = sessionId;
+  FString subscriptionGiftResult;
+  FJsonObjectConverter::UStructToJsonObjectString(
+      subscriptionGiftRequest, subscriptionGiftResult, 0, 0, 0, nullptr, false);
+  subscriptions.Add(subscribeResult);
+
   //  subscriptions.Add("channel.subscription.message");
   //  subscriptions.Add("channel.raid");
 

--- a/Source/TwitchInteraction/Public/TwitchEventSub.h
+++ b/Source/TwitchInteraction/Public/TwitchEventSub.h
@@ -294,6 +294,72 @@ public:
 
 // END channel.subscribe
 
+// BEGIN channel.subscription.gift
+USTRUCT(BlueprintType)
+struct FTwitchEventNotificationEventSubscriptionGift {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString user_id;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString user_login;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString user_name;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_id;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_login;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_name;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  int total;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString tier;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  int cumulative_total;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  bool is_anonymous;
+};
+
+USTRUCT(BlueprintType) struct FTwitchEventSubSubscriptionGiftPayload {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventNotificationEventSubscriptionGift event;
+};
+
+USTRUCT(BlueprintType)
+struct FTwitchEventSubSubscriptionGiftMessage {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventSubSubscriptionGiftPayload payload;
+};
+
+USTRUCT(BlueprintType)
+struct FTwitchEventSubSubscriptionGiftRequestCondition {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_id;
+};
+
+USTRUCT(BlueprintType)
+struct FTwitchEventSubSubscriptionSubscriptionGiftRequest {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString type;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString version;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventSubSubscriptionGiftRequestCondition condition;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventSubSubscriptionRequestTransport transport;
+};
+
+// END channel.subscription.gift
+
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
     FChannelPointsRedeemed,
     const FTwitchEventNotificationEventChannelPointRedeemEvent &,
@@ -304,6 +370,10 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
     FChannelSubscribed, const FTwitchEventNotificationEventSubscribe &,
     channelSubscribeInfo);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
+    FChannelSubscriptionGifted,
+    const FTwitchEventNotificationEventSubscriptionGift &,
+    channelSubscriptionGiftInfo);
 
 UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
 class TWITCHINTERACTION_API UTwitchEventSub : public UActorComponent {
@@ -368,6 +438,9 @@ public:
 
   UPROPERTY(BlueprintAssignable, Category = "Message Events")
   FChannelSubscribed OnChannelSubscribed;
+
+  UPROPERTY(BlueprintAssignable, Category = "Message Events")
+  FChannelSubscriptionGifted OnChannelSubscriptionGifted;
 
 private:
   uint32 requestCounter = 0;

--- a/Source/TwitchInteraction/Public/TwitchEventSub.h
+++ b/Source/TwitchInteraction/Public/TwitchEventSub.h
@@ -437,6 +437,74 @@ public:
 
 // END channel.subscription.message
 
+// BEGIN channel.raid
+USTRUCT(BlueprintType)
+struct FTwitchEventNotificationEventRaidMessage {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString text;
+};
+
+USTRUCT(BlueprintType)
+struct FTwitchEventNotificationEventRaid {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString from_broadcaster_user_id;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString from_broadcaster_user_login;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString from_broadcaster_user_name;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString to_broadcaster_user_id;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString to_broadcaster_user_login;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString to_broadcaster_user_name;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  int viewers;
+};
+
+USTRUCT(BlueprintType) struct FTwitchEventSubRaidPayload {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventNotificationEventRaid event;
+};
+
+USTRUCT(BlueprintType)
+struct FTwitchEventSubRaidMessage {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventSubRaidPayload payload;
+};
+
+USTRUCT(BlueprintType)
+struct FTwitchEventSubSubscriptionRaidRequestCondition {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_id;
+};
+
+USTRUCT(BlueprintType)
+struct FTwitchEventSubSubscriptionRaidRequest {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString type;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString version;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventSubSubscriptionRaidRequestCondition condition;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventSubSubscriptionRequestTransport transport;
+};
+
+// END channel.raid
+
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
     FChannelPointsRedeemed,
     const FTwitchEventNotificationEventChannelPointRedeemEvent &,
@@ -455,6 +523,8 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
     FChannelSubscriptionRenewed,
     const FTwitchEventNotificationEventSubscriptionRenew &,
     channelSubscriptionRenewInfo);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
+    FChannelRaided, const FTwitchEventNotificationEventRaid &, channelRaidInfo);
 
 UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
 class TWITCHINTERACTION_API UTwitchEventSub : public UActorComponent {
@@ -525,6 +595,9 @@ public:
 
   UPROPERTY(BlueprintAssignable, Category = "Message Events")
   FChannelSubscriptionRenewed OnChannelSubscriptionRenewed;
+
+  UPROPERTY(BlueprintAssignable, Category = "Message Events")
+  FChannelRaided OnChannelRaided;
 
 private:
   uint32 requestCounter = 0;

--- a/Source/TwitchInteraction/Public/TwitchEventSub.h
+++ b/Source/TwitchInteraction/Public/TwitchEventSub.h
@@ -2,22 +2,22 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
-#include "Networking.h"
-#include "Misc/DateTime.h"
-#include "Runtime/Engine/Public/TimerManager.h"
-#include "WebSocketsModule.h"
-#include "IWebSocket.h"
+#include "CoreMinimal.h"
 #include "HttpModule.h"
+#include "IWebSocket.h"
 #include "Interfaces/IHttpRequest.h"
 #include "Interfaces/IHttpResponse.h"
+#include "Misc/DateTime.h"
+#include "Networking.h"
+#include "Runtime/Engine/Public/TimerManager.h"
+#include "WebSocketsModule.h"
+
 #include "TwitchEventSub.generated.h"
 
 // BEGIN Generic data structures for all events
 USTRUCT(BlueprintType)
-struct FTwitchEventSubSubscriptionRequestTransport
-{
+struct FTwitchEventSubSubscriptionRequestTransport {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -27,8 +27,7 @@ public:
 };
 
 USTRUCT(BlueprintType)
-struct FTwitchEventNotificationReward
-{
+struct FTwitchEventNotificationReward {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -42,8 +41,7 @@ public:
 };
 
 USTRUCT(BlueprintType)
-struct FTwitchEventSubMessageMetadata
-{
+struct FTwitchEventSubMessageMetadata {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -59,8 +57,7 @@ public:
 };
 
 USTRUCT(BlueprintType)
-struct FTwitchEventSubMessage
-{
+struct FTwitchEventSubMessage {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -68,8 +65,7 @@ public:
 };
 
 USTRUCT(BlueprintType)
-struct FTwitchEventSubMessageWelcomePayloadSession
-{
+struct FTwitchEventSubMessageWelcomePayloadSession {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -85,8 +81,7 @@ public:
 };
 
 USTRUCT(BlueprintType)
-struct FTwitchEventSubMessageWelcomePayload
-{
+struct FTwitchEventSubMessageWelcomePayload {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -94,8 +89,7 @@ public:
 };
 
 USTRUCT(BlueprintType)
-struct FTwitchEventSubMessageWelcome
-{
+struct FTwitchEventSubMessageWelcome {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -107,29 +101,27 @@ public:
 
 // BEGIN channel.follow
 USTRUCT(BlueprintType)
-struct FTwitchEventNotificationEventChannelFollowEvent
-{
+struct FTwitchEventNotificationEventChannelFollowEvent {
   GENERATED_USTRUCT_BODY()
 public:
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
-    FString user_id;
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
-    FString user_login;
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
-    FString user_name;
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
-    FString broadcaster_user_id;
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
-    FString broadcaster_user_login;
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
-    FString broadcaster_user_name;
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
-    FString followed_at;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString user_id;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString user_login;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString user_name;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_id;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_login;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_name;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString followed_at;
 };
 
 USTRUCT(BlueprintType)
-struct FTwitchEventSubChannelFollowPayload
-{
+struct FTwitchEventSubChannelFollowPayload {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -137,8 +129,7 @@ public:
 };
 
 USTRUCT(BlueprintType)
-struct FTwitchEventSubChannelFollowMessage
-{
+struct FTwitchEventSubChannelFollowMessage {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -146,8 +137,7 @@ public:
 };
 
 USTRUCT(BlueprintType)
-struct FTwitchEventSubSubscriptionFollowRequestCondition
-{
+struct FTwitchEventSubSubscriptionFollowRequestCondition {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -157,8 +147,7 @@ public:
 };
 
 USTRUCT(BlueprintType)
-struct FTwitchEventSubSubscriptionChannelFollowRequest
-{
+struct FTwitchEventSubSubscriptionChannelFollowRequest {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -176,8 +165,7 @@ public:
 // BEGIN channel.channel_points_custom_reward.add
 
 USTRUCT(BlueprintType)
-struct FTwitchEventNotificationEventChannelPointRedeemEvent
-{
+struct FTwitchEventNotificationEventChannelPointRedeemEvent {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -205,8 +193,7 @@ public:
 };
 
 USTRUCT(BlueprintType)
-struct FTwitchEventSubChannelPointRedeemPayload
-{
+struct FTwitchEventSubChannelPointRedeemPayload {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -214,18 +201,15 @@ public:
 };
 
 USTRUCT(BlueprintType)
-struct FTwitchEventSubChannelPointRedeemMessage
-{
+struct FTwitchEventSubChannelPointRedeemMessage {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
   FTwitchEventSubChannelPointRedeemPayload payload;
 };
 
-
 USTRUCT(BlueprintType)
-struct FTwitchEventSubSubscriptionChannelPointRequestCondition
-{
+struct FTwitchEventSubSubscriptionChannelPointRequestCondition {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -233,8 +217,7 @@ public:
 };
 
 USTRUCT(BlueprintType)
-struct FTwitchEventSubSubscriptionChannelPointRequest
-{
+struct FTwitchEventSubSubscriptionChannelPointRequest {
   GENERATED_USTRUCT_BODY()
 public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
@@ -249,13 +232,81 @@ public:
 
 // END channel.channel_points_custom_reward.add
 
+// BEGIN channel.subscribe
+USTRUCT(BlueprintType)
+struct FTwitchEventNotificationEventSubscribe {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString user_id;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString user_login;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString user_name;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_id;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_login;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_name;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString tier;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  bool is_gift;
+};
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FChannelPointsRedeemed, const FTwitchEventNotificationEventChannelPointRedeemEvent &, channelPointsInfo);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FChannelFollowed, const FTwitchEventNotificationEventChannelFollowEvent&, channelFollowInfo);
+USTRUCT(BlueprintType) struct FTwitchEventSubSubscriptionPayload {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventNotificationEventSubscribe event;
+};
+
+USTRUCT(BlueprintType)
+struct FTwitchEventSubSubscriptionMessage {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventSubSubscriptionPayload payload;
+};
+
+USTRUCT(BlueprintType)
+struct FTwitchEventSubSubscriptionSubscribeRequestCondition {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_id;
+};
+
+USTRUCT(BlueprintType)
+struct FTwitchEventSubSubscriptionSubscribeRequest {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString type;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString version;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventSubSubscriptionSubscribeRequestCondition condition;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventSubSubscriptionRequestTransport transport;
+};
+
+// END channel.subscribe
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
+    FChannelPointsRedeemed,
+    const FTwitchEventNotificationEventChannelPointRedeemEvent &,
+    channelPointsInfo);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
+    FChannelFollowed, const FTwitchEventNotificationEventChannelFollowEvent &,
+    channelFollowInfo);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
+    FChannelSubscribed, const FTwitchEventNotificationEventSubscribe &,
+    channelSubscribeInfo);
 
 UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
-class TWITCHINTERACTION_API UTwitchEventSub : public UActorComponent
-{
+class TWITCHINTERACTION_API UTwitchEventSub : public UActorComponent {
   GENERATED_BODY()
 
 public:
@@ -292,10 +343,13 @@ protected:
 
 public:
   // Called every frame
-  virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction *ThisTickFunction) override;
+  virtual void
+  TickComponent(float DeltaTime, ELevelTick TickType,
+                FActorComponentTickFunction *ThisTickFunction) override;
 
   UFUNCTION(BlueprintCallable, Category = "Setup")
-  void SetInfo(const FString _oauth, const FString _authType = "Bearer", const FString _channelId = "0", const FString _clientId = "0");
+  void SetInfo(const FString _oauth, const FString _authType = "Bearer",
+               const FString _channelId = "0", const FString _clientId = "0");
 
   UFUNCTION(BlueprintCallable, Category = "Setup")
   bool Connect(FString &result);
@@ -311,6 +365,9 @@ public:
 
   UPROPERTY(BlueprintAssignable, Category = "Message Events")
   FChannelFollowed OnChannelFollowed;
+
+  UPROPERTY(BlueprintAssignable, Category = "Message Events")
+  FChannelSubscribed OnChannelSubscribed;
 
 private:
   uint32 requestCounter = 0;

--- a/Source/TwitchInteraction/Public/TwitchEventSub.h
+++ b/Source/TwitchInteraction/Public/TwitchEventSub.h
@@ -360,6 +360,83 @@ public:
 
 // END channel.subscription.gift
 
+// BEGIN channel.subscription.message
+USTRUCT(BlueprintType)
+struct FTwitchEventNotificationEventSubscriptionRenewMessage {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString text;
+  // We ignore the emotes for now, will review later
+};
+
+USTRUCT(BlueprintType)
+struct FTwitchEventNotificationEventSubscriptionRenew {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString user_id;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString user_login;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString user_name;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_id;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_login;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_name;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString tier;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventNotificationEventSubscriptionRenewMessage message;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  int cumulative_months;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  int streak_months;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  int duration_months;
+};
+
+USTRUCT(BlueprintType) struct FTwitchEventSubSubscriptionRenewPayload {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventNotificationEventSubscriptionRenew event;
+};
+
+USTRUCT(BlueprintType)
+struct FTwitchEventSubSubscriptionRenewMessage {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventSubSubscriptionRenewPayload payload;
+};
+
+USTRUCT(BlueprintType)
+struct FTwitchEventSubSubscriptionRenewRequestCondition {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString broadcaster_user_id;
+};
+
+USTRUCT(BlueprintType)
+struct FTwitchEventSubSubscriptionSubscriptionRenewRequest {
+  GENERATED_USTRUCT_BODY()
+public:
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString type;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FString version;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventSubSubscriptionRenewRequestCondition condition;
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "TwitchInteraction")
+  FTwitchEventSubSubscriptionRequestTransport transport;
+};
+
+// END channel.subscription.message
+
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
     FChannelPointsRedeemed,
     const FTwitchEventNotificationEventChannelPointRedeemEvent &,
@@ -374,6 +451,10 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
     FChannelSubscriptionGifted,
     const FTwitchEventNotificationEventSubscriptionGift &,
     channelSubscriptionGiftInfo);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
+    FChannelSubscriptionRenewed,
+    const FTwitchEventNotificationEventSubscriptionRenew &,
+    channelSubscriptionRenewInfo);
 
 UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
 class TWITCHINTERACTION_API UTwitchEventSub : public UActorComponent {
@@ -441,6 +522,9 @@ public:
 
   UPROPERTY(BlueprintAssignable, Category = "Message Events")
   FChannelSubscriptionGifted OnChannelSubscriptionGifted;
+
+  UPROPERTY(BlueprintAssignable, Category = "Message Events")
+  FChannelSubscriptionRenewed OnChannelSubscriptionRenewed;
 
 private:
   uint32 requestCounter = 0;


### PR DESCRIPTION
Adds support for the following events:
- `channel.subscribe`
- `channel.subscription.gift`
- `channel.subscription.message` (which is for renewals)
- `channel.raid`